### PR TITLE
fix iteration of cf properties, dont hardcode route

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ wrangler generate wasm-worker https://github.com/pinatasoftware/confetti-templat
 cd wasm-worker
 ```
 
+### Build and publish with `wrangler`
+
+```
+wrangler publish
+```
+
 ### 🛠️ Build with `wasm-pack build`
 
 ```

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -22,10 +22,11 @@ async function handleRequest(request) {
     headers[key] = request.headers.get(key);
   }
 
-  var cf = {};
+  let cf = {};
   if (request.cf !== undefined) {
-    for (var key of request.cf.keys()) {
-      cf[key] = request.cf.get(key);
+    for (let key in request.cf) {
+      // confetti seems to treat cf as a HashMap<String, String>, even though it has nested objects
+      cf[key] = JSON.stringify(request.cf[key]);
     }
   }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,7 +2,5 @@ name = "confetti-template"
 type = "rust"
 account_id = ""
 workers_dev = false
-routes = [
-    "*www.pinatasoftware.dev/*",
-]
+route = ""
 zone_id = ""


### PR DESCRIPTION
Hey, not sure if you were intending this template for public consumption.  I see confetti is published on crates.io but the repo linked from there (https://github.com/pinatasoftware/confetti) isn't publicly available.

This pr changes the template such that it works out of the box for other people trying the standard wrangler generate + wrangler publish workflow.